### PR TITLE
log master segfaults and dont hijack the caught signal

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@ Name
 Description
 ===========
 
-* It can be used to dump backtrace of nginx in case a worker process exits abnormally, e.g. when some signal is received (SIGABR, SIGBUS, SIGFPE, SIGILL, SIGIOT, SIGSEGV). It's quite handy for debugging purpose.
+* It can be used to dump backtrace of nginx in case an Nginx process (master or worker) exits abnormally, e.g. when some signal is received (SIGABR, SIGBUS, SIGFPE, SIGILL, SIGIOT, SIGSEGV). It's quite handy for debugging purpose.
 * This module requires the libunwind API. You can't enable it on systems lack of this library, Check if your system is supported in http://www.nongnu.org/libunwind/index.html
 
 Installing Dependencies (Debian/Ubuntu)

--- a/ngx_backtrace_module.c
+++ b/ngx_backtrace_module.c
@@ -301,7 +301,7 @@ ngx_error_signal_handler (int signo, siginfo_t *info, void *ptr) {
 
 bye:
 
-    _exit(1);
+    return;
 invalid:
 
     kill(ngx_getpid(), signo);

--- a/ngx_backtrace_module.c
+++ b/ngx_backtrace_module.c
@@ -29,7 +29,7 @@
 
 static char *ngx_backtrace_files(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
 static void ngx_error_signal_handler(int signo, siginfo_t *info, void *secret);
-static ngx_int_t ngx_backtrace_init_worker(ngx_cycle_t *cycle);
+static ngx_int_t ngx_backtrace_init_module(ngx_cycle_t *cycle);
 static void *ngx_backtrace_create_conf(ngx_cycle_t *cycle);
 #if defined(nginx_version) && nginx_version >= 1005002
 static ngx_log_t *ngx_log_create(ngx_cycle_t *cycle, ngx_str_t *name);
@@ -114,8 +114,8 @@ ngx_module_t  ngx_backtrace_module = {
     ngx_backtrace_commands,                /* module directives */
     NGX_CORE_MODULE,                       /* module type */
     NULL,                                  /* init master */
-    NULL,                                  /* init module */
-    ngx_backtrace_init_worker,             /* init process */
+    ngx_backtrace_init_module,             /* init module */
+    NULL,                                  /* init process */
     NULL,                                  /* init thread */
     NULL,                                  /* exit thread */
     NULL,                                  /* exit process */
@@ -338,7 +338,7 @@ ngx_backtrace_files(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 }
 
 static ngx_int_t
-ngx_backtrace_init_worker(ngx_cycle_t *cycle)
+ngx_backtrace_init_module(ngx_cycle_t *cycle)
 {
     ngx_backtrace_conf_t *bcf;
 


### PR DESCRIPTION
* Don't hijack the caught signal completely

Previously after the backtrace log was written by the module it would simply
exit the process, which means that the signal is not processed further by the
system and nothing is written to syslog (which is bad for issue monitoring).

Changed this to not exit the process so the system handles the signal as usual,
and this module only adds the writing of backtrace log on top of that
(which imho is the expected behavior).

* Write backtrace log for master process segfaults as well 